### PR TITLE
Update TerrainAffordances.xml

### DIFF
--- a/Languages/Russian/DefInjected/TerrainAffordanceDef/TerrainAffordances.xml
+++ b/Languages/Russian/DefInjected/TerrainAffordanceDef/TerrainAffordances.xml
@@ -1,6 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-  <!-- Deep water bridges can be built here -->
-  <!-- EN <BridgeableDeep.label>bridgeable deep</BridgeableDeep.label> -->
-  <BridgeableDeep.label>можно строить глубоководный мост</BridgeableDeep.label>
+
+	<!-- Deep water bridges can be built here -->
+
+	<!-- EN: bridgeable deep -->
+	<BridgeableDeep.label>можно строить глубоководный мост</BridgeableDeep.label>
+
 </LanguageData>


### PR DESCRIPTION
some cosmetics for further translations

A bit more cosmetics:
- Can you rename the "Russian" folder into "Russian (Русский)"? Not nessessary but more correct (do you see russian symbols? here is printscreen:)
![folder](https://user-images.githubusercontent.com/46885477/110077360-c8fd8380-7da7-11eb-9398-2b1e7411fc44.jpg)

- Look another one:
![golden tiles and bridge](https://user-images.githubusercontent.com/46885477/110077430-eaf70600-7da7-11eb-84b3-cb0d3448ce08.jpg)
golden bridge looks like gilt wood. But sterile bridge is really ideal! I tried to patch TexturePath:
![patch](https://user-images.githubusercontent.com/46885477/110077698-6b1d6b80-7da8-11eb-9efd-dcc31700268d.jpg)
but nothing changed. Can you change the basic texture for metal bridges? Or tell me the correct xpath for patching? mailto:uncleshvya@yandex.ru
