### PR TITLE
Create Keys.xml

### DIFF
--- a/Languages/Russian/Keyed/Keys.xml
+++ b/Languages/Russian/Keyed/Keys.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+
+	<!-- EN: NoFloorsOnBridges -->
+	<NoFloorsOnBridges>Нельзя изменить настил, не разбирая мост.</NoFloorsOnBridges>
+
+</LanguageData>


### PR DESCRIPTION
added russian translation string

it works good, see printscreen:
![NoFloorsOnBridges](https://user-images.githubusercontent.com/46885477/110078240-45449680-7da9-11eb-90d5-963aef6d8a55.jpg)
but causes an error in TranslationReport. Maybe because it is hidden deep in SimplyMoreBridges.dll? I have taken tag "NoFloorsOnBridges" from older mod version.

And I can translate mode options' variables, if you tell me these tags:
![ModOptions](https://user-images.githubusercontent.com/46885477/110078689-ef242300-7da9-11eb-9add-0e8e0738adf4.jpg)
mailto:uncleshvya@yandex.ru
It'll be also useful for other languages.